### PR TITLE
Change <= to >= in product view of num_sold

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -267,7 +267,7 @@ class Products(ViewSet):
 
         if number_sold is not None:
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 


### PR DESCRIPTION
Fixed bug for query of products sold by a certain amount
## Changes

- number_sold if statement changed from <= to >=

## Requests / Responses


**Request**

GET `/products?number_sold=1` get products sold at least 1 time



**Response**

HTTP/1.1 201 OK

```json
[
    {
        "id": 45,
        "name": "Corvette",
        "price": 795.8,
        "number_sold": 1,
        "description": "1987 Chevrolet",
        "quantity": 2,
        "created_date": "2019-10-07",
        "location": "Ueno",
        "image_path": null,
        "average_rating": null
    },
    {
        "id": 50,
        "name": "Escalade EXT",
        "price": 926.92,
        "number_sold": 2,
        "description": "2008 Cadillac",
        "quantity": 2,
        "created_date": "2019-02-01",
        "location": "Lokavec",
        "image_path": null,
        "average_rating": 3.25
    }
]
```

## Testing

Description of how to test code...

- [ ] query for 1 or 2 items sold


## Related Issues

