### PR TITLE
Jv ticket 2

### DIFF
--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -104,7 +104,7 @@ class Orders(ViewSet):
         """
         customer = Customer.objects.get(user=request.auth.user)
         payment_type = Payment.objects.get(pk=request.data["payment_type"])
-        order = Order.objects.get(pk=pk, customer=customer)
+        order = Order.objects.get(pk=pk)
         order.payment_type = payment_type
         order.save()
 

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -103,8 +103,9 @@ class Orders(ViewSet):
             HTTP/1.1 204 No Content
         """
         customer = Customer.objects.get(user=request.auth.user)
+        payment_type = Payment.objects.get(pk=request.data["payment_type"])
         order = Order.objects.get(pk=pk, customer=customer)
-        order.payment_type = request.data["payment_type"]
+        order.payment_type = payment_type
         order.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -207,7 +207,7 @@ class Profile(ViewSet):
             """
 
             try:
-                open_order = Order.objects.get(customer=current_user)
+                open_order = Order.objects.get(customer=current_user, payment_type=None)
                 print(open_order)
             except Order.DoesNotExist as ex:
                 open_order = Order()
@@ -283,6 +283,17 @@ class Profile(ViewSet):
         return Response(serializer.data)
 
 
+class OrderSerializer(serializers.HyperlinkedModelSerializer):
+    """JSON serializer for customer orders"""
+
+    class Meta:
+        model = Order
+        url = serializers.HyperlinkedIdentityField(
+            view_name='order',
+            lookup_field='id'
+        )
+        fields = ('id', 'url', 'created_date', 'payment_type', 'customer',)
+
 class LineItemSerializer(serializers.HyperlinkedModelSerializer):
     """JSON serializer for products
 
@@ -290,9 +301,10 @@ class LineItemSerializer(serializers.HyperlinkedModelSerializer):
         serializers
     """
     product = ProductSerializer(many=False)
+    order = OrderSerializer(many=False)
     class Meta:
         model = OrderProduct
-        fields = ('id', 'product')
+        fields = ('id', 'product', 'order')
         depth = 1
 
 class UserSerializer(serializers.HyperlinkedModelSerializer):

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -211,7 +211,7 @@ class Profile(ViewSet):
                 print(open_order)
             except Order.DoesNotExist as ex:
                 open_order = Order()
-                open_order.created_date = datetime.datetime.now()
+                open_order.created_date = date.datetime.now()
                 open_order.customer = current_user
                 open_order.save()
 

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -211,7 +211,7 @@ class Profile(ViewSet):
                 print(open_order)
             except Order.DoesNotExist as ex:
                 open_order = Order()
-                open_order.created_date = date.datetime.now()
+                open_order.created_date = datetime.date.now()
                 open_order.customer = current_user
                 open_order.save()
 


### PR DESCRIPTION
Fixes for ticket #2 Orders now close properly and when a product is added to an empty cart a new order is created

## Changes

- Order serializer to added product to cart
- Payment type object is get then assigned to an order when PUT order/# w/payment_type
- When a new product is added to a cart, added query parameter of an Order with payment_type:null

## Requests / Responses



**Request**

POST `/profile/cart` assigns a product to an open order, and if no open order exists creates a new order instance
```json
{
    "product_id": 88
}
```

**Response**

HTTP/1.1 201 OK

```json
{
    "id": 15,
    "product": {
        "id": 88,
        "name": "Element",
        "price": 1727.41,
        "number_sold": 4,
        "description": "2003 Honda",
        "quantity": 3,
        "created_date": "2019-05-28",
        "location": "Dukoh",
        "image_path": null,
        "average_rating": null
    },
    "order": {
        "id": 11,
        "url": "http://localhost:8000/orders/11",
        "created_date": "2021-02-11",
        "payment_type": null,
        "customer": "http://localhost:8000/customers/4"
    }
}
```

**Request**

PUT `/orders/#` assigns a payment to an open order, saves it
```json
{
    "payment_type": 1
}
```

**Response**

HTTP/1.1 201 OK

```json
{ }
```

## Testing

Description of how to test code...

- [x] Authenticate the client and get a token
- [x] Create a payment type
- [x] Add a product to the cart by sending a POST request to http://localhost:8000/profile/cart
- [x] Finish the order by sending a PUT request to the order's URL
- [ ] Add a product to the cart by sending a POST request to http://localhost:8000/profile/cart


## Related Issues

- Fixes #2