### PR TITLE
Added location filter for Products GET

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -249,6 +249,10 @@ class Products(ViewSet):
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
         min_price = self.request.query_params.get('min_price', None)
+        location = self.request.query_params.get('location', None)
+
+        if location is not None:
+            products =  products.filter(location__contains=location)
 
         if order is not None:
             order_filter = order


### PR DESCRIPTION
Added  Location filter to Products GET
## Changes

- Added  Location filter to Products GET


## Requests / Responses


**Request**
GET `/products?location=Onguday` Returns all products with the location of Onguday


```

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 1,
        "name": "Optima",
        "price": 1655.15,
        "number_sold": 0,
        "description": "2008 Kia",
        "quantity": 3,
        "created_date": "2019-05-21",
        "location": "Onguday",
        "image_path": null,
        "average_rating": null
    }
]
```

## Testing

Description of how to test code...

- [ ] Run  `products?location=Onguday`


## Related Issues

- Fixes #13 